### PR TITLE
Change Mastodon back to Twitter

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <html>
 
  <!--
-  _______                _                              _   _           _ 
+  _______                _                              _   _           _
  |__   __|              | |                            | | | |         | |
     | | ___  _ __ ___   | |      _____      _____ _ __ | |_| |__   __ _| |
     | |/ _ \| '_ ` _ \  | |     / _ \ \ /\ / / _ \ '_ \| __| '_ \ / _` | |
@@ -58,15 +58,15 @@
           <img src="./img/icons/instagram.png" alt="Instagram">
           </a></li>
 	<li>
-          <a href="https://mastodon.social/@tomlowenthal" rel="me">
-          <img src="./img/icons/heffalump.png" alt="Mastodon">
+          <a href="https://twitter.com/flamsmark" rel="me">
+          <img src="./img/icons/twitter.png" alt="Twitter">
           </a></li>
        <li>
           <a href="https://github.com/tomlowenthal" rel="me">
           <img src="./img/icons/github.png" alt="Github">
           </a></li>
         </ul>
-      </div> 
+      </div>
 
     </div>
 


### PR DESCRIPTION
Change the link, icon, and alt text of the microblogging link back to 
Twitter.